### PR TITLE
added support for video file size

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,9 +274,9 @@ origURL | OK | - | The URL of the original asset in photo library, if it exists
 isVertical | OK | OK | Will be true if the image is vertically oriented
 width | OK | OK | Image dimensions (photos only)
 height | OK | OK | Image dimensions (photos only)
-fileSize | OK | OK | The file size (photos only)
+fileSize | OK | OK | The file size
 type | - | OK | The file type (photos only)
-fileName | OK (photos and videos) | OK (photos) | The file name
+fileName | OK | OK | The file name
 path | - | OK | The file path
 latitude | OK | OK | Latitude metadata, if available
 longitude | OK | OK | Longitude metadata, if available

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -375,6 +375,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     }
 
     Uri uri = null;
+    String realPath = null;
     switch (requestCode)
     {
       case REQUEST_LAUNCH_IMAGE_CAPTURE:
@@ -383,7 +384,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
       case REQUEST_LAUNCH_IMAGE_LIBRARY:
         uri = data.getData();
-        String realPath = getRealPathFromURI(uri);
+        realPath = getRealPathFromURI(uri);
         final boolean isUrl = !TextUtils.isEmpty(realPath) &&
                 Patterns.WEB_URL.matcher(realPath).matches();
         if (realPath == null || isUrl)
@@ -408,18 +409,22 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
         break;
 
       case REQUEST_LAUNCH_VIDEO_LIBRARY:
-        responseHelper.putString("uri", data.getData().toString());
-        responseHelper.putString("path", getRealPathFromURI(data.getData()));
+        uri = data.getData();
+        realPath = getRealPathFromURI(uri);
+        responseHelper.putString("uri", uri.toString());
+        responseHelper.putString("path", realPath);
+        putExtraFileInfo(realPath, responseHelper);
         responseHelper.invokeResponse(callback);
         callback = null;
         return;
 
       case REQUEST_LAUNCH_VIDEO_CAPTURE:
         uri = data.getData();
-        final String path = getRealPathFromURI(uri);
+        realPath = getRealPathFromURI(uri);
         responseHelper.putString("uri", uri.toString());
-        responseHelper.putString("path", path);
-        fileScan(reactContext, path, uri);
+        responseHelper.putString("path", realPath);
+        fileScan(reactContext, realPath, uri);
+        putExtraFileInfo(realPath, responseHelper);
         responseHelper.invokeResponse(callback);
         callback = null;
         return;

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -427,6 +427,13 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
             NSURL *videoURL = info[UIImagePickerControllerMediaURL];
             NSURL *videoDestinationURL = [NSURL fileURLWithPath:path];
 
+            NSNumber *fileSizeValue = nil;
+            NSError *fileSizeError = nil;
+            [videoURL getResourceValue:&fileSizeValue forKey:NSURLFileSizeKey error:&fileSizeError];
+            if (fileSizeValue){
+                [self.response setObject:fileSizeValue forKey:@"fileSize"];
+            }
+
             if (videoRefURL) {
                 PHAsset *pickedAsset = [PHAsset fetchAssetsWithALAssetURLs:@[videoRefURL] options:nil].lastObject;
                 NSString *originalFilename = [self originalFilenameForAsset:pickedAsset assetType:PHAssetResourceTypeVideo];


### PR DESCRIPTION
## Motivation

For Amica use case: DPA-12334, where checking the size of the video fails since there's no `fileSize` key on the response object.

## Test Plan

For this module, simply check response object for `fileSize`.
